### PR TITLE
Update Dockerfile to PHP 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tugboatqa/php:7.4-apache
+FROM tugboatqa/php:8.0-apache
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 


### PR DESCRIPTION
For the upgrade to Open Social 9.4 we'll need to be able to test on PHP 8.0.

The Docker image we're now using for Tugboat only support PHP 7.4.