### PR TITLE
Update PHP to 8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tugboatqa/php:8.0-apache
+FROM tugboatqa/php:8.1-apache
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 


### PR DESCRIPTION
In order for Open Social to be compatible with PHP 8.1 we need to bump the PHP version for Tugboat environments, so we test it there.